### PR TITLE
Adds platform version to allow local use on Vaughn's computer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-darwin-21
 
 DEPENDENCIES


### PR DESCRIPTION
Attempts to run this app locally required the addition of a `PLATFORM` value to `Gemfile.lock`. This should not affect other platforms.